### PR TITLE
docs: Integrate mifos-workflow with asciidoctor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### Documentation ###
+docs/generated/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # mifos-workflow
+
+## Documentation
+
+Documentation is available in the `docs/` directory. To generate HTML documentation:
+
+```bash
+mvn asciidoctor:process-asciidoc
+```
+
+The generated documentation will be available in `docs/generated/`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,59 @@
+# Mifos-Workflow Documentation Setup
+
+This directory contains the AsciiDoc documentation setup for the project.
+
+## Structure
+
+- `asciidoc/` - Source AsciiDoc files
+  - `index.adoc` - Main documentation template
+- `generated/` - Generated HTML documentation (gitignored)
+
+## Building Documentation
+
+### Prerequisites
+
+- Java 21
+- Maven 3.6+
+
+### Generate HTML Documentation
+
+```bash
+mvn asciidoctor:process-asciidoc
+```
+
+This will generate HTML files in the `docs/generated/` directory.
+
+### View Documentation
+
+After generation, open `docs/generated/index.html` in your browser.
+
+## Writing Documentation
+
+### AsciiDoc Syntax
+
+The documentation uses AsciiDoc format. Key features:
+
+- **Headers**: Use `=`, `==`, `===` for different heading levels
+- **Code blocks**: Use `[source,language]` followed by `----` for code blocks
+- **Links**: Use `link:url[text]` for external links
+- **Includes**: Use `include::filename.adoc[]` to include other files
+
+### Adding New Documentation
+
+1. Create a new `.adoc` file in the `asciidoc/` directory
+2. Add the include directive to `index.adoc` if you want it in the main documentation
+3. Run `mvn asciidoctor:process-asciidoc` to generate updated HTML
+
+## Configuration
+
+The AsciiDoc Maven plugin is configured in `pom.xml` with the following settings:
+
+- **Source directory**: `docs/asciidoc/`
+- **Output directory**: `docs/generated/`
+- **Backend**: HTML5
+- **Doctype**: Book
+- **Features**: Table of contents, syntax highlighting, section numbering
+
+## Continuous Integration
+
+The documentation is automatically generated during the Maven build process in the `prepare-package` phase. 

--- a/docs/asciidoc/index.adoc
+++ b/docs/asciidoc/index.adoc
@@ -1,0 +1,33 @@
+= Mifos-Workflow Project Documentation
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:highlightjs-theme: github
+:toc: left
+:toclevels: 3
+:sectnums:
+:sectanchors:
+
+== Introduction
+
+Add your project introduction here.
+
+== Getting Started
+
+Add getting started information here.
+
+== Configuration
+
+Add configuration details here.
+
+== API Reference
+
+Add API documentation here.
+
+== Development
+
+Add development guidelines here.
+
+== Contributing
+
+Add contribution guidelines here. 

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,36 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctor-maven-plugin</artifactId>
+                <version>2.2.1</version>
+                <configuration>
+                    <sourceDirectory>docs/asciidoc</sourceDirectory>
+                    <outputDirectory>docs/generated</outputDirectory>
+                    <backend>html5</backend>
+                    <doctype>book</doctype>
+                    <attributes>
+                        <toc>left</toc>
+                        <toclevels>3</toclevels>
+                        <sectnums>true</sectnums>
+                        <sectanchors>true</sectanchors>
+                        <source-highlighter>highlightjs</source-highlighter>
+                        <highlightjs-theme>github</highlightjs-theme>
+                        <icons>font</icons>
+                        <experimental>true</experimental>
+                    </attributes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>generate-docs</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
# Description

- Added AsciiDoc Maven plugin (asciidoctor-maven-plugin:2.2.1) to pom.xml
- Configured source directory: `docs/asciidoc/`
- Configured output directory: `docs/generated/`
- Set up HTML5 backend with enhanced features
- Added docs/README.md, a Comprehensive guide for writing and maintaining documentation




