### PR TITLE
Feat/add structured api responses

### DIFF
--- a/src/main/java/org/mifos/workflow/controller/AuthenticationController.java
+++ b/src/main/java/org/mifos/workflow/controller/AuthenticationController.java
@@ -9,6 +9,7 @@ import org.mifos.workflow.exception.FineractApiException;
 import org.mifos.workflow.service.fineract.auth.FineractAuthService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.mifos.workflow.util.ApiResponse;
 import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
@@ -56,10 +57,10 @@ public class AuthenticationController {
     }
 
     @DeleteMapping("/logout")
-    public ResponseEntity<Void> logout() {
+    public ResponseEntity<ApiResponse<Void>> logout() {
         log.info("Logout request received");
         fineractAuthService.clearCachedAuthKey();
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.success("Logged out successfully"));
     }
 
 

--- a/src/main/java/org/mifos/workflow/controller/ClientOffboardingController.java
+++ b/src/main/java/org/mifos/workflow/controller/ClientOffboardingController.java
@@ -16,6 +16,7 @@ import org.mifos.workflow.core.model.TaskInfo;
 import org.mifos.workflow.dto.fineract.client.ClientCloseRequestDTO;
 import org.mifos.workflow.service.WorkflowService;
 import org.springframework.http.ResponseEntity;
+import org.mifos.workflow.util.ApiResponse;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -68,11 +69,11 @@ public class ClientOffboardingController {
     }
 
     @PostMapping("/tasks/{taskId}/complete")
-    public ResponseEntity<Void> completeOffboardingTask(@PathVariable String taskId, @RequestBody Map<String, Object> taskVariables) {
+    public ResponseEntity<ApiResponse<Void>> completeOffboardingTask(@PathVariable String taskId, @RequestBody Map<String, Object> taskVariables) {
         log.info("Completing offboarding task: {}", taskId);
         workflowService.completeTask(taskId, taskVariables);
         log.info("Offboarding task {} completed successfully", taskId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.success("Offboarding task completed successfully"));
     }
 
     @GetMapping("/processes/{processInstanceId}/variables")
@@ -131,11 +132,11 @@ public class ClientOffboardingController {
     }
 
     @DeleteMapping("/processes/{processInstanceId}")
-    public ResponseEntity<Void> terminateProcess(@PathVariable String processInstanceId) {
+    public ResponseEntity<ApiResponse<Void>> terminateProcess(@PathVariable String processInstanceId) {
         log.info("Terminating process instance: {}", processInstanceId);
         workflowService.terminateProcess(processInstanceId, "Manual termination via API");
         log.info("Process instance {} terminated successfully", processInstanceId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.success("Process terminated successfully"));
     }
 
     @GetMapping("/processes/{processInstanceId}/status")
@@ -181,11 +182,11 @@ public class ClientOffboardingController {
     }
 
     @DeleteMapping("/deployments/{deploymentId}")
-    public ResponseEntity<Void> deleteDeployment(@PathVariable String deploymentId) {
+    public ResponseEntity<ApiResponse<Void>> deleteDeployment(@PathVariable String deploymentId) {
         log.info("Deleting deployment: {}", deploymentId);
         workflowService.deleteDeployment(deploymentId);
         log.info("Deployment {} deleted successfully", deploymentId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.success("Deployment deleted successfully"));
     }
 
     @PostMapping("/deployments")

--- a/src/main/java/org/mifos/workflow/controller/ClientOnboardingController.java
+++ b/src/main/java/org/mifos/workflow/controller/ClientOnboardingController.java
@@ -16,6 +16,7 @@ import org.mifos.workflow.core.model.ProcessStatus;
 import org.mifos.workflow.core.model.TaskInfo;
 import org.mifos.workflow.dto.fineract.client.ClientCreateRequestDTO;
 import org.mifos.workflow.service.WorkflowService;
+import org.mifos.workflow.util.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -86,7 +87,7 @@ public class ClientOnboardingController {
     }
 
     @PostMapping("/tasks/{taskId}/complete")
-    public ResponseEntity<Void> completeVerificationTask(@PathVariable String taskId, @RequestBody Map<String, Object> taskVariables) {
+    public ResponseEntity<ApiResponse<Void>> completeVerificationTask(@PathVariable String taskId, @RequestBody Map<String, Object> taskVariables) {
 
         log.info("Completing verification task: {}", taskId);
 
@@ -99,7 +100,7 @@ public class ClientOnboardingController {
         workflowService.completeTask(taskId, taskVariables);
 
         log.info("Verification task {} completed successfully", taskId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.success("Verification task completed successfully"));
     }
 
     @GetMapping("/processes/{processInstanceId}/variables")
@@ -173,14 +174,14 @@ public class ClientOnboardingController {
     }
 
     @DeleteMapping("/processes/{processInstanceId}")
-    public ResponseEntity<Void> terminateProcess(@PathVariable String processInstanceId) {
+    public ResponseEntity<ApiResponse<Void>> terminateProcess(@PathVariable String processInstanceId) {
 
         log.info("Terminating process instance: {}", processInstanceId);
 
         workflowService.terminateProcess(processInstanceId, "Manual termination via API");
 
         log.info("Process instance {} terminated successfully", processInstanceId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.success("Process terminated successfully"));
     }
 
     @GetMapping("/processes/{processInstanceId}/status")
@@ -239,14 +240,14 @@ public class ClientOnboardingController {
     }
 
     @DeleteMapping("/deployments/{deploymentId}")
-    public ResponseEntity<Void> deleteDeployment(@PathVariable String deploymentId) {
+    public ResponseEntity<ApiResponse<Void>> deleteDeployment(@PathVariable String deploymentId) {
 
         log.info("Deleting deployment: {}", deploymentId);
 
         workflowService.deleteDeployment(deploymentId);
 
         log.info("Deployment {} deleted successfully", deploymentId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.success("Deployment deleted successfully"));
     }
 
     @PostMapping("/deployments")

--- a/src/main/java/org/mifos/workflow/controller/ClientTransferController.java
+++ b/src/main/java/org/mifos/workflow/controller/ClientTransferController.java
@@ -16,6 +16,7 @@ import org.mifos.workflow.core.model.TaskInfo;
 import org.mifos.workflow.dto.fineract.client.ClientTransferRequestDTO;
 import org.mifos.workflow.service.WorkflowService;
 import org.springframework.http.ResponseEntity;
+import org.mifos.workflow.util.ApiResponse;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -62,11 +63,11 @@ public class ClientTransferController {
     }
 
     @PostMapping("/tasks/{taskId}/complete")
-    public ResponseEntity<Void> completeTransferTask(@PathVariable String taskId, @RequestBody Map<String, Object> taskVariables) {
+    public ResponseEntity<ApiResponse<Void>> completeTransferTask(@PathVariable String taskId, @RequestBody Map<String, Object> taskVariables) {
         log.info("Completing transfer task: {}", taskId);
         workflowService.completeTask(taskId, taskVariables);
         log.info("Transfer task {} completed successfully", taskId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.success("Transfer task completed successfully"));
     }
 
     @GetMapping("/processes/{processInstanceId}/variables")
@@ -125,11 +126,11 @@ public class ClientTransferController {
     }
 
     @DeleteMapping("/processes/{processInstanceId}")
-    public ResponseEntity<Void> terminateProcess(@PathVariable String processInstanceId) {
+    public ResponseEntity<ApiResponse<Void>> terminateProcess(@PathVariable String processInstanceId) {
         log.info("Terminating process instance: {}", processInstanceId);
         workflowService.terminateProcess(processInstanceId, "Manual termination via API");
         log.info("Process instance {} terminated successfully", processInstanceId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.success("Process terminated successfully"));
     }
 
     @GetMapping("/processes/{processInstanceId}/status")
@@ -175,11 +176,11 @@ public class ClientTransferController {
     }
 
     @DeleteMapping("/deployments/{deploymentId}")
-    public ResponseEntity<Void> deleteDeployment(@PathVariable String deploymentId) {
+    public ResponseEntity<ApiResponse<Void>> deleteDeployment(@PathVariable String deploymentId) {
         log.info("Deleting deployment: {}", deploymentId);
         workflowService.deleteDeployment(deploymentId);
         log.info("Deployment {} deleted successfully", deploymentId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.success("Deployment deleted successfully"));
     }
 
     @PostMapping("/deployments")

--- a/src/main/java/org/mifos/workflow/controller/LoanCancellationController.java
+++ b/src/main/java/org/mifos/workflow/controller/LoanCancellationController.java
@@ -7,6 +7,7 @@ import org.mifos.workflow.dto.fineract.loan.LoanCancellationRequestDTO;
 import org.mifos.workflow.service.WorkflowService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.mifos.workflow.util.ApiResponse;
 import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
@@ -55,7 +56,7 @@ public class LoanCancellationController {
 
 
     @PostMapping("/tasks/{taskId}/complete")
-    public ResponseEntity<Void> completeTask(@PathVariable String taskId,
+    public ResponseEntity<ApiResponse<Void>> completeTask(@PathVariable String taskId,
                                              @RequestBody Map<String, Object> variables) {
         log.info("Completing task in loan cancellation workflow. Task ID: {}", taskId);
 
@@ -75,7 +76,7 @@ public class LoanCancellationController {
 
         workflowService.completeTask(taskId, variables);
         log.info("Task completed successfully. Task ID: {}", taskId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.success("Task completed successfully"));
     }
 
 
@@ -106,12 +107,12 @@ public class LoanCancellationController {
 
 
     @PostMapping("/processes/{processInstanceId}/terminate")
-    public ResponseEntity<Void> terminateProcess(@PathVariable String processInstanceId,
+    public ResponseEntity<ApiResponse<Void>> terminateProcess(@PathVariable String processInstanceId,
                                                  @RequestBody ProcessTerminationRequest request) {
         log.info("Terminating process instance. Process Instance ID: {}", processInstanceId);
 
         workflowService.terminateProcess(processInstanceId, request.getReason());
         log.info("Process instance terminated successfully. Process Instance ID: {}", processInstanceId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.success("Process terminated successfully"));
     }
 }

--- a/src/main/java/org/mifos/workflow/controller/LoanDisbursementController.java
+++ b/src/main/java/org/mifos/workflow/controller/LoanDisbursementController.java
@@ -6,6 +6,7 @@ import org.mifos.workflow.core.model.*;
 import org.mifos.workflow.dto.fineract.loan.LoanDisbursementRequestDTO;
 import org.mifos.workflow.service.WorkflowService;
 import org.springframework.http.ResponseEntity;
+import org.mifos.workflow.util.ApiResponse;
 import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
@@ -117,7 +118,7 @@ public class LoanDisbursementController {
     }
 
     @PostMapping("/retry/{processInstanceId}")
-    public ResponseEntity<ProcessInstance> retryDisbursement(@PathVariable String processInstanceId,
+    public ResponseEntity<ApiResponse<Void>> retryDisbursement(@PathVariable String processInstanceId,
                                                              @RequestBody Map<String, Object> retryVariables) {
         log.info("Retrying loan disbursement for process instance: {}", processInstanceId);
 
@@ -132,11 +133,11 @@ public class LoanDisbursementController {
             workflowService.completeTask(tasks.get(0).getTaskId(), retryVariables);
         }
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.success("Disbursement retry triggered"));
     }
 
     @PostMapping("/escalate/{processInstanceId}")
-    public ResponseEntity<Void> escalateDisbursement(@PathVariable String processInstanceId,
+    public ResponseEntity<ApiResponse<Void>> escalateDisbursement(@PathVariable String processInstanceId,
                                                      @RequestBody Map<String, Object> escalationVariables) {
         log.info("Escalating loan disbursement for process instance: {}", processInstanceId);
 
@@ -146,11 +147,11 @@ public class LoanDisbursementController {
 
         workflowService.setProcessVariables(processInstanceId, escalationVariables);
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.success("Disbursement escalated"));
     }
 
     @PostMapping("/approve/{processInstanceId}")
-    public ResponseEntity<Void> approveDisbursement(@PathVariable String processInstanceId,
+    public ResponseEntity<ApiResponse<Void>> approveDisbursement(@PathVariable String processInstanceId,
                                                     @RequestBody Map<String, Object> approvalVariables) {
         log.info("Approving loan disbursement for process instance: {}", processInstanceId);
 
@@ -168,11 +169,11 @@ public class LoanDisbursementController {
             }
         }
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.success("Disbursement approved"));
     }
 
     @PostMapping("/reject/{processInstanceId}")
-    public ResponseEntity<Void> rejectDisbursement(@PathVariable String processInstanceId,
+    public ResponseEntity<ApiResponse<Void>> rejectDisbursement(@PathVariable String processInstanceId,
                                                    @RequestBody Map<String, Object> rejectionVariables) {
         log.info("Rejecting loan disbursement for process instance: {}", processInstanceId);
 
@@ -190,7 +191,7 @@ public class LoanDisbursementController {
             }
         }
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.success("Disbursement rejected"));
     }
 
     @GetMapping("/tasks")
@@ -208,11 +209,11 @@ public class LoanDisbursementController {
     }
 
     @PostMapping("/tasks/{taskId}/complete")
-    public ResponseEntity<Void> completeTask(@PathVariable String taskId, @RequestBody Map<String, Object> taskVariables) {
+    public ResponseEntity<ApiResponse<Void>> completeTask(@PathVariable String taskId, @RequestBody Map<String, Object> taskVariables) {
         log.info("Completing task: {} with variables: {}", taskId, taskVariables);
         workflowService.completeTask(taskId, taskVariables);
         log.info("Task {} completed successfully", taskId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.success("Task completed successfully"));
     }
 
     @GetMapping("/processes/{processInstanceId}/variables")
@@ -223,10 +224,10 @@ public class LoanDisbursementController {
     }
 
     @PostMapping("/processes/{processInstanceId}/variables")
-    public ResponseEntity<Void> setProcessVariables(@PathVariable String processInstanceId, @RequestBody Map<String, Object> variables) {
+    public ResponseEntity<ApiResponse<Void>> setProcessVariables(@PathVariable String processInstanceId, @RequestBody Map<String, Object> variables) {
         log.info("Setting variables for process instance: {} with variables: {}", processInstanceId, variables);
         workflowService.setProcessVariables(processInstanceId, variables);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.success("Process variables updated"));
     }
 
     @GetMapping("/processes")
@@ -244,11 +245,11 @@ public class LoanDisbursementController {
     }
 
     @DeleteMapping("/processes/{processInstanceId}")
-    public ResponseEntity<Void> terminateProcess(@PathVariable String processInstanceId) {
+    public ResponseEntity<ApiResponse<Void>> terminateProcess(@PathVariable String processInstanceId) {
         log.info("Terminating process instance: {}", processInstanceId);
         workflowService.terminateProcess(processInstanceId, "Manual termination via API");
         log.info("Process instance {} terminated successfully", processInstanceId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.success("Process terminated successfully"));
     }
 
     @GetMapping("/processes/{processInstanceId}/status")

--- a/src/main/java/org/mifos/workflow/controller/LoanOriginationController.java
+++ b/src/main/java/org/mifos/workflow/controller/LoanOriginationController.java
@@ -7,6 +7,7 @@ import org.mifos.workflow.dto.fineract.loan.LoanCreateRequestDTO;
 import org.mifos.workflow.dto.fineract.loan.LoanApprovalRequestDTO;
 import org.mifos.workflow.dto.fineract.loan.LoanRejectionRequestDTO;
 import org.mifos.workflow.service.WorkflowService;
+import org.mifos.workflow.util.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -157,7 +158,7 @@ public class LoanOriginationController {
     }
 
     @PostMapping("/tasks/{taskId}/complete")
-    public ResponseEntity<Void> completeTask(@PathVariable String taskId, @RequestBody Map<String, Object> taskVariables) {
+    public ResponseEntity<ApiResponse<Void>> completeTask(@PathVariable String taskId, @RequestBody Map<String, Object> taskVariables) {
         log.info("Completing task: {} with variables: {}", taskId, taskVariables);
 
         if (taskVariables.containsKey("loanType")) {
@@ -169,7 +170,7 @@ public class LoanOriginationController {
 
         workflowService.completeTask(taskId, taskVariables);
         log.info("Task {} completed successfully", taskId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.success("Task completed successfully"));
     }
 
     @GetMapping("/processes/{processInstanceId}/variables")
@@ -194,18 +195,18 @@ public class LoanOriginationController {
     }
 
     @PostMapping("/processes/{processInstanceId}/variables")
-    public ResponseEntity<Void> setProcessVariables(@PathVariable String processInstanceId, @RequestBody Map<String, Object> variables) {
+    public ResponseEntity<ApiResponse<Void>> setProcessVariables(@PathVariable String processInstanceId, @RequestBody Map<String, Object> variables) {
         log.info("Setting variables for process instance: {} with variables: {}", processInstanceId, variables);
         workflowService.setProcessVariables(processInstanceId, variables);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.success("Process variables updated"));
     }
 
     @DeleteMapping("/processes/{processInstanceId}")
-    public ResponseEntity<Void> terminateProcess(@PathVariable String processInstanceId) {
+    public ResponseEntity<ApiResponse<Void>> terminateProcess(@PathVariable String processInstanceId) {
         log.info("Terminating process instance: {}", processInstanceId);
         workflowService.terminateProcess(processInstanceId, "Manual termination via API");
         log.info("Process instance {} terminated successfully", processInstanceId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.success("Process terminated successfully"));
     }
 
     @GetMapping("/processes/{processInstanceId}/status")

--- a/src/main/java/org/mifos/workflow/core/engine/delegates/LoanDisbursementDelegate.java
+++ b/src/main/java/org/mifos/workflow/core/engine/delegates/LoanDisbursementDelegate.java
@@ -123,9 +123,12 @@ public class LoanDisbursementDelegate implements JavaDelegate {
         }
         request.put("actualDisbursementDate", disbursementDateStr);
 
-        Object amt = execution.getVariable("transactionAmount");
+        Object approvedAmt = execution.getVariable("approvedAmount");
+        Object originalAmt = execution.getVariable("transactionAmount");
+        Object amt = approvedAmt != null ? approvedAmt : originalAmt;
         if (amt != null) {
             request.put("transactionAmount", amt);
+            log.info("Using amount for disbursement: {} (approved: {}, original: {})", amt, approvedAmt, originalAmt);
         }
         Object note = execution.getVariable("note");
         if (note != null) {

--- a/src/main/java/org/mifos/workflow/util/ApiResponse.java
+++ b/src/main/java/org/mifos/workflow/util/ApiResponse.java
@@ -1,0 +1,70 @@
+package org.mifos.workflow.util;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.Instant;
+
+/*
+ * Generic API response wrapper.
+ * @param <T> the type of the response data
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+
+    private boolean success;
+    private String message;
+    private T data;
+    private Instant timestamp;
+
+    public ApiResponse() {
+    }
+
+    public ApiResponse(boolean success, String message, T data, Instant timestamp) {
+        this.success = success;
+        this.message = message;
+        this.data = data;
+        this.timestamp = timestamp;
+    }
+
+    public static <T> ApiResponse<T> success(String message) {
+        return new ApiResponse<>(true, message, null, Instant.now());
+    }
+
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(true, message, data, Instant.now());
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public void setSuccess(boolean success) {
+        this.success = success;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public void setData(T data) {
+        this.data = data;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+    }
+}
+
+

--- a/src/test/java/org/mifos/workflow/controller/AuthenticationControllerTest.java
+++ b/src/test/java/org/mifos/workflow/controller/AuthenticationControllerTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.mifos.workflow.util.ApiResponse;
 import io.reactivex.rxjava3.core.Observable;
 import retrofit2.HttpException;
 import retrofit2.Response;
@@ -146,12 +147,14 @@ class AuthenticationControllerTest {
         doNothing().when(fineractAuthService).clearCachedAuthKey();
 
         // When
-        ResponseEntity<Void> response = authenticationController.logout();
+        ResponseEntity<ApiResponse<Void>> response = authenticationController.logout();
 
         // Then
         assertNotNull(response);
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertNull(response.getBody());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().isSuccess());
+        assertEquals("Logged out successfully", response.getBody().getMessage());
         verify(fineractAuthService).clearCachedAuthKey();
     }
 }

--- a/src/test/java/org/mifos/workflow/controller/ClientOffboardingControllerTest.java
+++ b/src/test/java/org/mifos/workflow/controller/ClientOffboardingControllerTest.java
@@ -21,6 +21,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
+import org.mifos.workflow.util.ApiResponse;
 import org.springframework.mock.web.MockMultipartFile;
 
 import java.io.IOException;
@@ -111,7 +112,7 @@ class ClientOffboardingControllerTest {
         doNothing().when(workflowService).completeTask(anyString(), any(Map.class));
 
         // When
-        ResponseEntity<Void> response = clientOffboardingController.completeOffboardingTask("task-123", taskVariables);
+        ResponseEntity<ApiResponse<Void>> response = clientOffboardingController.completeOffboardingTask("task-123", taskVariables);
 
         // Then
         assertNotNull(response);
@@ -268,7 +269,7 @@ class ClientOffboardingControllerTest {
         doNothing().when(workflowService).terminateProcess(anyString(), anyString());
 
         // When
-        ResponseEntity<Void> response = clientOffboardingController.terminateProcess("process-123");
+        ResponseEntity<ApiResponse<Void>> response = clientOffboardingController.terminateProcess("process-123");
 
         // Then
         assertNotNull(response);
@@ -384,7 +385,7 @@ class ClientOffboardingControllerTest {
         doNothing().when(workflowService).deleteDeployment("deploy-123");
 
         // When
-        ResponseEntity<Void> response = clientOffboardingController.deleteDeployment("deploy-123");
+        ResponseEntity<ApiResponse<Void>> response = clientOffboardingController.deleteDeployment("deploy-123");
 
         // Then
         assertNotNull(response);

--- a/src/test/java/org/mifos/workflow/controller/ClientOnboardingControllerTest.java
+++ b/src/test/java/org/mifos/workflow/controller/ClientOnboardingControllerTest.java
@@ -17,6 +17,7 @@ import org.mifos.workflow.core.model.ProcessVariables;
 import org.mifos.workflow.core.model.TaskInfo;
 import org.mifos.workflow.dto.fineract.client.ClientCreateRequestDTO;
 import org.mifos.workflow.service.WorkflowService;
+import org.mifos.workflow.util.ApiResponse;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -97,7 +98,7 @@ class ClientOnboardingControllerTest {
         doNothing().when(workflowService).completeTask(anyString(), any(Map.class));
 
         // When
-        ResponseEntity<Void> response = clientOnboardingController.completeVerificationTask("task-123", taskVariables);
+        ResponseEntity<ApiResponse<Void>> response = clientOnboardingController.completeVerificationTask("task-123", taskVariables);
 
         // Then
         assertNotNull(response);
@@ -254,7 +255,7 @@ class ClientOnboardingControllerTest {
         doNothing().when(workflowService).terminateProcess(anyString(), anyString());
 
         // When
-        ResponseEntity<Void> response = clientOnboardingController.terminateProcess("process-123");
+        ResponseEntity<ApiResponse<Void>> response = clientOnboardingController.terminateProcess("process-123");
 
         // Then
         assertNotNull(response);
@@ -370,7 +371,7 @@ class ClientOnboardingControllerTest {
         doNothing().when(workflowService).deleteDeployment("deploy-123");
 
         // When
-        ResponseEntity<Void> response = clientOnboardingController.deleteDeployment("deploy-123");
+        ResponseEntity<ApiResponse<Void>> response = clientOnboardingController.deleteDeployment("deploy-123");
 
         // Then
         assertNotNull(response);

--- a/src/test/java/org/mifos/workflow/controller/ClientTransferControllerTest.java
+++ b/src/test/java/org/mifos/workflow/controller/ClientTransferControllerTest.java
@@ -21,6 +21,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
+import org.mifos.workflow.util.ApiResponse;
 import org.springframework.mock.web.MockMultipartFile;
 
 import java.io.IOException;
@@ -111,7 +112,7 @@ class ClientTransferControllerTest {
         doNothing().when(workflowService).completeTask(anyString(), any(Map.class));
 
         // When
-        ResponseEntity<Void> response = clientTransferController.completeTransferTask("task-123", taskVariables);
+        ResponseEntity<ApiResponse<Void>> response = clientTransferController.completeTransferTask("task-123", taskVariables);
 
         // Then
         assertNotNull(response);
@@ -269,7 +270,7 @@ class ClientTransferControllerTest {
         doNothing().when(workflowService).terminateProcess(anyString(), anyString());
 
         // When
-        ResponseEntity<Void> response = clientTransferController.terminateProcess("process-123");
+        ResponseEntity<ApiResponse<Void>> response = clientTransferController.terminateProcess("process-123");
 
         // Then
         assertNotNull(response);
@@ -385,7 +386,7 @@ class ClientTransferControllerTest {
         doNothing().when(workflowService).deleteDeployment("deploy-123");
 
         // When
-        ResponseEntity<Void> response = clientTransferController.deleteDeployment("deploy-123");
+        ResponseEntity<ApiResponse<Void>> response = clientTransferController.deleteDeployment("deploy-123");
 
         // Then
         assertNotNull(response);


### PR DESCRIPTION
# Description

-  Created Standard API Response wrapper
   -  success: a boolean flag indicating operation success
   - message: descriptive success message
   - data: optional payload data (generic type)
   - timestamp: ISO timestamp of the response
   - Static factory methods for easy response creation

- Updated Controller Endpoint  to return `ResponseEntity<ApiResponse<Void>>` instead of `ResponseEntity<Void>`
- Updated all corresponding test files to expect `ResponseEntity<ApiResponse<Void>>` instead of `ResponseEntity<Void>`
- Fixed the loan disbursement delegate class to use the approved amount instead of the transaction amount in the manager review task while loan disbursing 
