### PR TITLE
Add @NotBlank validation to AuthenticationRequest DTO fields

### DIFF
--- a/src/main/java/org/mifos/workflow/dto/fineract/auth/AuthenticationRequest.java
+++ b/src/main/java/org/mifos/workflow/dto/fineract/auth/AuthenticationRequest.java
@@ -1,4 +1,5 @@
 package org.mifos.workflow.dto.fineract.auth;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Data;
 
@@ -9,6 +10,10 @@ import lombok.Data;
 @Data
 @Builder
 public class AuthenticationRequest {
+
+    @NotBlank(message = "Username must not be blank")
     private String username;
+
+    @NotBlank(message = "Password must not be blank")
     private String password;
 }


### PR DESCRIPTION
fix: Add validation constraints to AuthenticationRequest DTO

Problem:
- AuthenticationController uses @Valid but DTO lacked validation annotations
- Blank username/password bypassed local validation
- Caused unnecessary external calls to Fineract API
- Returned less informative error responses to clients

Solution:
- Added @NotBlank(message = "Username must not be blank") to username field
- Added @NotBlank(message = "Password must not be blank") to password field

Impact:
- Early validation prevents external API calls
- Clearer error messages for clients
- Reduced unnecessary network overhead