### PR TITLE
Replace @NotNull with @NotBlank on String fields in ClientCreateRequestDTO

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
             <scope>runtime</scope>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,11 +62,6 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
-            <version>3.1.1</version>
-        </dependency>
         <!-- Database -->
         <dependency>
             <groupId>com.mysql</groupId>

--- a/src/main/java/org/mifos/workflow/dto/fineract/auth/AuthenticationRequest.java
+++ b/src/main/java/org/mifos/workflow/dto/fineract/auth/AuthenticationRequest.java
@@ -1,4 +1,5 @@
 package org.mifos.workflow.dto.fineract.auth;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Data;
 
@@ -9,6 +10,10 @@ import lombok.Data;
 @Data
 @Builder
 public class AuthenticationRequest {
+
+    @NotBlank(message = "Username must not be blank")
     private String username;
+
+    @NotBlank(message = "Password must not be blank")
     private String password;
 }

--- a/src/main/java/org/mifos/workflow/dto/fineract/client/ClientCreateRequestDTO.java
+++ b/src/main/java/org/mifos/workflow/dto/fineract/client/ClientCreateRequestDTO.java
@@ -1,5 +1,6 @@
 package org.mifos.workflow.dto.fineract.client;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Data;
 import org.mifos.workflow.dto.fineract.address.AddressDTO;
@@ -20,15 +21,15 @@ import java.util.stream.Collectors;
 @Builder
 public class ClientCreateRequestDTO {
     private static final String DEFAULT_DATE_FORMAT = "dd MMMM yyyy";
-    @NotNull
+    @NotBlank(message = "First name is required and cannot be blank")
     private String firstName;
-    @NotNull
+    @NotBlank(message = "Last name is required and cannot be blank")
     private String lastName;
     @NotNull
     private Long officeId;
-    @NotNull
+    @NotBlank
     private String dateFormat;
-    @NotNull
+    @NotBlank
     private String locale;
     @NotNull
     private Boolean active;

--- a/src/test/java/org/mifos/workflow/controller/AuthenticationControllerValidationTest.java
+++ b/src/test/java/org/mifos/workflow/controller/AuthenticationControllerValidationTest.java
@@ -1,0 +1,72 @@
+package org.mifos.workflow.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.mifos.workflow.dto.fineract.auth.AuthenticationRequest;
+import org.mifos.workflow.service.fineract.auth.FineractAuthService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AuthenticationController.class)
+class AuthenticationControllerValidationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private FineractAuthService fineractAuthService; // mock the dependency
+
+    @Test
+    void shouldReturnBadRequestWhenUsernameIsBlank() throws Exception {
+        AuthenticationRequest request = AuthenticationRequest.builder()
+                .username("")
+                .password("validPass")
+                .build();
+
+        mockMvc.perform(post("/api/v1/auth/authenticate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.fieldErrors.username").value("Username must not be blank"))
+                .andExpect(jsonPath("$.fieldErrors.password").doesNotExist());
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenPasswordIsBlank() throws Exception {
+        AuthenticationRequest request = AuthenticationRequest.builder()
+                .username("user")
+                .password("")
+                .build();
+
+        mockMvc.perform(post("/api/v1/auth/authenticate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.fieldErrors.password").value("Password must not be blank"))
+                .andExpect(jsonPath("$.fieldErrors.username").doesNotExist());
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenBothAreBlank() throws Exception {
+        AuthenticationRequest request = AuthenticationRequest.builder()
+                .username("")
+                .password("")
+                .build();
+
+        mockMvc.perform(post("/api/v1/auth/authenticate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.fieldErrors.username").value("Username must not be blank"))
+                .andExpect(jsonPath("$.fieldErrors.password").value("Password must not be blank"));
+    }
+}


### PR DESCRIPTION
**Problem -** 

The client creation endpoint was not validating input strings properly. Requests with empty or whitespace-only values for fields like firstName were being accepted and passed to the service layer, resulting in:

500 Internal Server Error with CLIENT_CREATION_FAILED

Poor developer experience (unclear error messages)

Risk of corrupted or invalid data entering the system

Screenshot of the issue:
<img width="750" height="677" alt="Screenshot 2026-07-17 at 12 47 22 AM" src="https://github.com/user-attachments/assets/cf728b0f-1b66-4659-810d-80bd706f425d" />

Root Cause
Two issues were identified:

Missing validation provider – The spring-boot-starter-validation dependency was not present in the pom.xml. Spring Boot logged a warning at startup: 

`Failed to set up a Bean Validation provider: NoProviderFoundException`

As a result, all @Valid and @NotNull annotations were ignored at runtime.

Incorrect annotation for string fields – @NotNull only checks for null values. It allows empty strings "" and whitespace " " to pass through validation. For fields like firstName, lastName, dateFormat, and locale, empty values are not meaningful and should be rejected. 

**Fix -**

Added missing dependency – Included spring-boot-starter-validation in pom.xml to enable the Bean Validation provider.

Replaced @NotNull with @NotBlank – For string fields that must contain actual text:

firstName

lastName

dateFormat

locale

Added descriptive error messages – Used the message attribute on @NotBlank to provide clear feedback to API consumers.

**Results After Fix -** 

Requests with empty or whitespace-only strings now return:

400 Bad Request with a clear validation error

Descriptive message: "First name is required and cannot be blank"

Proper field-level error reporting

Screenshot of the fix:
<img width="752" height="682" alt="Screenshot 2026-07-17 at 8 42 50 PM" src="https://github.com/user-attachments/assets/028ea5ea-5c11-441d-81b8-2b814c7dd729" />

## Test Results
All existing ClientOnboardingControllerTest tests pass with no failures.





