### PR TITLE
Remove deprecated default-authentication-plugin from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "3307:3306"
     volumes:
       - mysql-data:/var/lib/mysql
-    command: --default-authentication-plugin=mysql_native_password --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
       interval: 10s


### PR DESCRIPTION
## Summary
Remove the deprecated  "--default-authentication-plugin"  option from the 
MySQL service configuration in docker-compose.yml.

## Problem
MySQL 8.4 removed the default-authentication-plugin variable entirely.
Running docker compose up with the current configuration fails immediately 
with:

  unknown variable 'default-authentication-plugin=mysql_native_password'

<img width="1222" height="32" alt="Screenshot 2026-07-26 at 1 38 11 PM" src="https://github.com/user-attachments/assets/24d46144-c596-463a-ad7c-28f35c06487c" />


This causes the MySQL container to crash in a continuous restart loop, 
making the project impossible to run locally for new contributors without 
manual intervention.

## Root Cause
The docker-compose.yml MySQL command contained:
--default-authentication-plugin=mysql_native_password

This option was deprecated in MySQL 8.0 and fully removed in MySQL 8.4.

## Fix
Removed --default-authentication-plugin=mysql_native_password from the 
MySQL command. MySQL 8.4 uses caching_sha2_password by default which 
works correctly without this flag.

## Before / After
Before: docker compose up → MySQL crashes immediately, app never starts
After: docker compose up → MySQL starts healthy, app starts on port 8081

## Tested On
- MySQL 8.4 (Docker image mysql:8.4)
- Apple Silicon Mac (arm64)
- Docker Desktop latest stable