### PR TITLE
GAZ-308: Add PostgreSQL support, make datasource DB-agnostic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,11 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,15 +1,18 @@
 spring.application.name=mifos-workflow
 
 # DataSource configuration
-spring.datasource.url=jdbc:mysql://127.0.0.1:3307/mifos_flowable?characterEncoding=UTF-8
-spring.datasource.username=mifos
+# DB-agnostic: MySQL remains the default; override the vars below to run on another
+# database (e.g. PostgreSQL). Flowable auto-detects the engine from the connection.
+spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:mysql://127.0.0.1:3307/mifos_flowable?characterEncoding=UTF-8}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME:mifos}
 spring.datasource.password=${DB_PASSWORD}
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.driver-class-name=${SPRING_DATASOURCE_DRIVER_CLASS_NAME:com.mysql.cj.jdbc.Driver}
 
 # JPA/Hibernate settings
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+# Hibernate auto-detects the dialect from the JDBC connection (no hardcoded dialect,
+# so the same build works on MySQL or PostgreSQL).
 
 # Server port
 server.port=8081


### PR DESCRIPTION
## What
Makes the datasource **database-agnostic** so the same build runs on **MySQL (default) or PostgreSQL**, selected purely by configuration.

- `pom.xml`: add the `org.postgresql` driver (runtime) **alongside** the existing `mysql-connector-j`, one build now bundles both.
- `application.properties`: make `spring.datasource.url` / `username` / `driver-class-name` env-overridable with the **existing MySQL values kept as the defaults**, and remove the hardcoded `hibernate.dialect` so Hibernate auto-detects it from the live connection.

## Why
The service is currently hardcoded to MySQL (driver + JDBC URL + `MySQLDialect`), so it can't run on a PostgreSQL stack without patching the source. This lets operators point it at PostgreSQL via standard Spring env vars, while MySQL stays the out-of-the-box default. (Motivation: deploying the workflow engine into a PostgreSQL-standardised stack, Mifos Gazelle, whose shared database is PostgreSQL.)

## Non-breaking
- MySQL remains the default, with no env overrides, behaviour is unchanged.
- Both drivers ship, so existing MySQL users and the provided `docker-compose.yml` work exactly as before.
- No schema/entity impact: the app defines no JPA entities of its own; the DB holds only Flowable's tables, and Flowable ships per-database DDL and auto-detects the engine from the connection.

## Testing
Built and run against **PostgreSQL 16**: Flowable auto-detected Postgres and created its schema (`flowable.postgres.create.*.sql`), `/actuator/health` reports `db: PostgreSQL`, and a `client-onboarding` process started successfully (instance persisted). The MySQL path is unchanged (default config + bundled driver).

<pre> Run on PostgreSQL by setting: 
      SPRING_DATASOURCE_URL=jdbc:postgresql://&lt;host&gt;:5432/mifos_flowable          
      SPRING_DATASOURCE_USERNAME=&lt;user&gt; 
      SPRING_DATASOURCE_DRIVER_CLASS_NAME=org.postgresql.Driver 
      DB_PASSWORD=&lt;password&gt;  </pre>
